### PR TITLE
Allow sentences list to expand within the safe area

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -483,9 +483,9 @@ body.is-menu-closing .site-menu-toggle__icon span:nth-child(3) {
   align-items: stretch;
   width: min(920px, 100%);
   margin: 0 auto;
-  padding: clamp(48px, 22vh, 200px) clamp(24px, 8vw, 140px) clamp(200px, 52vh, 420px);
-  max-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
-  overflow: hidden;
+  padding-inline: clamp(24px, 8vw, 140px);
+  padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
+  scroll-padding-block: clamp(48px, 22vh, 200px) clamp(200px, 52vh, 420px);
   perspective: 1400px;
 }
 


### PR DESCRIPTION
## Summary
- let the sentences section expand naturally by removing the hard clipping
- rely on padding-block and scroll-padding so the safe-area masks remain unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8341af8b48331b55c4445590db45b