### PR TITLE
Attach sentence reveal updates to scroll container

### DIFF
--- a/script.js
+++ b/script.js
@@ -254,9 +254,21 @@
     });
   }
 
+  const scrollContainer = container.closest('.content');
+
   requestUpdate();
 
-  window.addEventListener('scroll', requestUpdate, { passive: true });
+  if (scrollContainer instanceof HTMLElement) {
+    scrollContainer.addEventListener('scroll', requestUpdate, { passive: true });
+
+    if ('ResizeObserver' in window) {
+      const resizeObserver = new ResizeObserver(() => requestUpdate());
+      resizeObserver.observe(scrollContainer);
+    }
+  } else {
+    window.addEventListener('scroll', requestUpdate, { passive: true });
+  }
+
   window.addEventListener('resize', requestUpdate);
 })();
 


### PR DESCRIPTION
## Summary
- detect the `.content` element that wraps the sentences and treat it as the scroll container
- listen for scroll (and resize when available) on that container so the sentence activation updates follow its position
- keep the initial request animation frame update to activate the first sentence on load

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d837b01d4c83319325057d73a7e9e2