### PR TITLE
Restore window scroll updates for sentence reveal

### DIFF
--- a/script.js
+++ b/script.js
@@ -254,9 +254,21 @@
     });
   }
 
+  const scrollContainer = container.closest('.content');
+
   requestUpdate();
 
   window.addEventListener('scroll', requestUpdate, { passive: true });
+
+  if (scrollContainer instanceof HTMLElement) {
+    scrollContainer.addEventListener('scroll', requestUpdate, { passive: true });
+
+    if ('ResizeObserver' in window) {
+      const resizeObserver = new ResizeObserver(() => requestUpdate());
+      resizeObserver.observe(scrollContainer);
+    }
+  }
+
   window.addEventListener('resize', requestUpdate);
 })();
 


### PR DESCRIPTION
## Summary
- keep the window-level scroll listener active for the sentence reveal logic
- still listen to the `.content` container and observe its size when available so desktop behaviour is unchanged

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d837b01d4c83319325057d73a7e9e2