### PR TITLE
Add safe-area top gradient overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,22 @@ body {
   z-index: 0;
 }
 
+.safe-frame::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  right: var(--safe-right);
+  left: var(--safe-left);
+  height: var(--safe-top);
+  background-image: linear-gradient(
+    to top,
+    var(--content-bg, var(--background, #000)) 0%,
+    #000 100%
+  );
+  pointer-events: none;
+  z-index: 1;
+}
+
 body.has-menu-open,
 body.is-menu-closing {
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add a fixed safe-area overlay gradient that fades the content background to black using the current safe inset values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83ff9556c83319321a3420d493155