### PR TITLE
Allow body to handle scrolling with safe-area padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -59,18 +59,14 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
 }
 
 .safe-frame {
-  position: fixed;
-  top: var(--safe-top);
-  right: var(--safe-right);
-  bottom: var(--safe-bottom);
-  left: var(--safe-left);
+  position: relative;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  contain: layout paint size;
+  min-height: calc((var(--viewport-unit) * 100) - (var(--safe-top) + var(--safe-bottom)));
   z-index: 0;
 }
 
@@ -120,9 +116,6 @@ body.is-menu-closing {
 .safe-frame .content {
   position: relative;
   flex: 1 1 auto;
-  height: 100%;
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- move safe-area handling to the body so the main scroll occurs on the document instead of the fixed frame
- relax the safe-frame container to flow with the page while preserving dynamic viewport sizing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d842f39e448331aadfede3ca0ff956